### PR TITLE
Update localvolrndcalculator.cpp

### DIFF
--- a/ql/methods/finitedifferences/utilities/localvolrndcalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/localvolrndcalculator.cpp
@@ -140,15 +140,23 @@ namespace QuantLib {
         else if (x > xr)
             return 1.0;
 
+        Real addition = 1.0;
         // left or right hand integral
         if (x > 0.5*(xr+xl)) {
-            while (pdf(xr, t) > 0.01*localVolProbEps_) xr*=1.1;
+            while (pdf(xr, t) > 0.01*localVolProbEps_) 
+            {
+                 addition*=1.1;
+                 xr+=addition;
+            }
 
             return 1.0-GaussLobattoIntegral(maxIter_, 0.1*localVolProbEps_)(
                 [&](Real _x){ return pdf(_x, t); }, x, xr);
         }
         else {
-            while (pdf(xl, t) > 0.01*localVolProbEps_) xl*=0.9;
+            while (pdf(xl, t) > 0.01*localVolProbEps_)
+            {
+                  addition=*1.1;
+                  xl-=addition;
 
             return GaussLobattoIntegral(maxIter_, 0.1*localVolProbEps_)(
                 [&](Real _x){ return pdf(_x, t); }, xl, x);


### PR DESCRIPTION
Computing cdf boundaries was wrong. In case xl is positive, while loop it lowers it but only to 0, if it is negative xl (through while loop) rise towards 0. In case xr is positive previous code is good as it tends towards +infinity. However, if xr is negative it tends towards -infinity.

xl should always tends towards -infinity and xr towards +infinity (up to a tolerance)

Maybe this can be done in better way, this is the first thing that come to my mind